### PR TITLE
sixaxis-helper: rename BT profiles for old BlueZ version

### DIFF
--- a/sixaxis-helper.sh
+++ b/sixaxis-helper.sh
@@ -62,6 +62,16 @@ sixaxis_timeout() {
     fi
 }
 
+sixaxis_rename() {
+    if grep "^Name=PLAYSTATION(R)3 Controller" /var/lib/bluetooth/*/*/info; then
+        echo "BlueZ <5.48 hack: renaming BT profile(s) to make consistent with kernel module name"
+        sed 's/.*Name=PLAYSTATION(R)3 Controller.*/Name=Sony PLAYSTATION(R)3 Controller/' -i /var/lib/bluetooth/*/*/info
+        systemctl restart bluetooth
+        exit
+    fi
+}
+
+sixaxis_rename
 sixaxis_calibrate
 sixaxis_timeout
 


### PR DESCRIPTION
Workaround for Raspbian stretch's version of BlueZ (5.43) that pre-dates this
commit: https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/plugins/sixaxis.c?id=7cdfddada0609d0df5cfe3fe3a2fba6355e53d26

Keeping the BT profile name in sync with the kernel name will allow the USB and BT connection to share the same controller mappings, which will reduce user confusion and  improve compatibility with future distribution releases that ship with later BlueZ versions.