### PR TITLE
sixaxis-helper: don't exit script when timeout is disabled

### DIFF
--- a/sixaxis-helper.sh
+++ b/sixaxis-helper.sh
@@ -86,5 +86,8 @@ sixaxis_rename
 sixaxis_calibrate
 if [[ "$SIXAXIS_TIMEOUT" != "0" ]]; then
     sixaxis_timeout
+else
+    # delay exit of service slice until device is removed
+    tail -f "$SIXAXIS_DEVICE" &>/dev/null
 fi
 exit 0


### PR DESCRIPTION
Keep the service active when the timeout is disabled to allow
a service slice restart to apply a new timeout correctly.