### PR TITLE
Added the ability to build/install/package using `cmake`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.6)
+project(sixaxis LANGUAGES C)
+
+add_executable(sixaxis-timeout sixaxis-timeout.c)
+
+# Point the service helper to the install location set by CMAKE_INSTALL_PREFIX
+configure_file(${CMAKE_SOURCE_DIR}/sixaxis@.service.in ${CMAKE_BINARY_DIR}/sixaxis@.service @ONLY)
+
+include(GNUInstallDirs)
+install(TARGETS sixaxis-timeout RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/sbin)
+install(FILES sixaxis-helper.sh DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(FILES 99-sixaxis.rules DESTINATION /etc/udev/rules.d)
+install(FILES ${CMAKE_BINARY_DIR}/sixaxis@.service DESTINATION /lib/systemd/system)
+install(FILES README.md COPYING DESTINATION ${CMAKE_INSTALL_FULL_DOCDIR})
+
+# Debian packaging
+#  - try to maintain the same version number as the one produced by 'checkinstall'
+execute_process(COMMAND date +%Y%m%d-1 OUTPUT_VARIABLE PACKAGE_VER OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# - the rest of the DEB generator options
+SET(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+SET(CPACK_GENERATOR "DEB")
+SET(CPACK_DEBIAN_PACKAGE_VERSION ${PACKAGE_VER})
+SET(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+SET(CPACK_DEBIAN_PACKAGE_NAME "sixaxis")
+SET(CPACK_DEBIAN_PACKAGE_SECTION "utils")
+SET(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Helper service for official and third-party Sony DualShock controllers")
+SET(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/RetroPie/sixaxis.git")
+SET(CPACK_DEBIAN_PACKAGE_DEPENDS "systemd, libevdev-tools, bluez")
+SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "RetroPie Project <retropieproject@gmail.com>")
+SET(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/debian/postinst;${CMAKE_SOURCE_DIR}/debian/postrm")
+INCLUDE(CPack)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sixaxis
+## sixaxis
 
 The sixaxis helper service is designed as a simple replacement for the sixad wrapper. It will
 * install udev rules to suppress the motion sensors node (as it causes issues with player slot assignment in emulators)
@@ -6,3 +6,41 @@ The sixaxis helper service is designed as a simple replacement for the sixad wra
 * implement a simple 10 minute idle timeout mechanism (as the bluez plugin does not support the standard IdleTimeout timer).
 
 The service is recommend for use with kernel 4.15 and Bluez 5.48 to ensure full compatibility with third-party controllers.
+
+## installation
+
+`cmake` / `make` is required to build the helper. `systemd`, `udev` and `libevdev-tools`(Debian/Ubuntu) or `libevdev-utils`(Fedora/Centos/SuSE) are required for running the helper.
+
+### build/install with `make`
+
+To build and install, run from the source folder:
+
+```
+make install
+```
+
+## build/install with `cmake`
+
+To build and install, run from the source folder
+```
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
+[sudo] make [install]
+# reload systemctl unit files
+[sudo] systemctl daemon-reload
+```
+
+Replace `CMAKE_INSTALL_PREFIX` with a different value of you wish to install to another prefix (i.e. `/opt`)
+
+## packaging with `cmake`
+
+To create a Debian `.deb` package, run from the source folder
+```
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
+make package
+# or
+cpack -GDEB .
+```
+
+This will create a `sixaxis` `.deb` package in the current build folder. Installing the package will add the necessary `udev` rules and reload `systemctl` automatically.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+if [ "$1" = configure ]
+then
+	systemctl daemon-reload
+fi

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+if [ "$1" = remove ]
+then
+	systemctl daemon-reload
+fi

--- a/postinstall-pak
+++ b/postinstall-pak
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# reload daemon configuration
-systemctl daemon-reload
-
-exit 0

--- a/sixaxis@.service.in
+++ b/sixaxis@.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=sixaxis helper (%I)
+
+[Service]
+Type=simple
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/sixaxis-helper.sh %I
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Makes it possible to create a `.deb` file, now that `checkinstall` is no longer included in Debian (and Raspi OS 64).
I think it should be merged into a separate branch, that we can use if/when we update the `sixaxis` RetroPie-Setup scriptmodule.